### PR TITLE
Add missing gir1.2-adw-1 to depends

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -20,6 +20,7 @@ Architecture: all
 Depends: ${misc:Depends},
          ${python3:Depends},
          dmidecode,
+         gir1.2-adw-1,
          gir1.2-glib-2.0,
          gir1.2-gtk-4.0,
          gir1.2-pango-1.0,


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/usr/share/system-monitoring-center/systemmonitoringcenter/Main.py", line 18, in on_activate
    from .MainWindow import MainWindow
  File "/usr/share/system-monitoring-center/systemmonitoringcenter/MainWindow.py", line 6, in <module>
    gi.require_version('Adw', '1')
  File "/usr/lib/python3/dist-packages/gi/__init__.py", line 126, in require_version
    raise ValueError('Namespace %s not available' % namespace)
ValueError: Namespace Adw not available
```