### PR TITLE
Improve cleanup and more

### DIFF
--- a/flatpak/io.github.hakandundar34coding.system-monitoring-center.yml
+++ b/flatpak/io.github.hakandundar34coding.system-monitoring-center.yml
@@ -5,12 +5,9 @@ sdk: org.gnome.Sdk
 command: system-monitoring-center
 
 finish-args:
-  # For X11 shared memory access (higher performance for X11)
   - --share=ipc
-  # For Wayland access
+  - --socket=x11
   - --socket=wayland
-  # For X11 fallback
-  - --socket=fallback-x11
   # For monitoring data download/upload speed on network cards
   - --device=all
   # For monitoring data download/upload speed on network cards

--- a/flatpak/io.github.hakandundar34coding.system-monitoring-center.yml
+++ b/flatpak/io.github.hakandundar34coding.system-monitoring-center.yml
@@ -23,9 +23,12 @@ finish-args:
 cleanup:
   - /include
   - /lib/pkgconfig
+  - /man
   - /share/man
   - /share/pkgconfig
   - /share/bash-completion
+  - '*.la'
+  - '*.a'
 
 modules:
 

--- a/flatpak/tkinter.json
+++ b/flatpak/tkinter.json
@@ -25,9 +25,7 @@
                 "chmod 755 /app/lib/libtcl*.so"
             ],
             "cleanup": [
-                "/bin",
-                "/lib/pkgconfig",
-                "/man"
+                "/bin"
             ],
             "sources": [
                 {
@@ -46,8 +44,7 @@
             ],
             "cleanup": [
                 "/bin",
-                "/lib/pkgconfig",
-                "/man"
+                "/lib/tk*/demos"
             ],
             "sources": [
                 {


### PR DESCRIPTION
- Improve cleanup commands
- Use x11, instead of fallback-x11 to fix tkinner error